### PR TITLE
Removed dark text variants as not working currently.

### DIFF
--- a/Code/Frontend/src/pages/blog/[slug].astro
+++ b/Code/Frontend/src/pages/blog/[slug].astro
@@ -28,7 +28,7 @@ const { date, title, components, properties } = Astro.props;
 
 <Layout>
   <MetaData slot="meta" metaProps={properties} />
-  <section class="py-10 px-8 bg-white dark:bg-dark">
+  <section class="py-10 px-8 bg-white">
     <div class="mx-auto max-w-7xl flex justify-end md:px-8 pb-8">
       <a
         class="border-indigo-600 border rounded-md inline-flex items-center justify-center py-3 px-7 text-center text-base font-medium text-indigo-600"
@@ -42,14 +42,14 @@ const { date, title, components, properties } = Astro.props;
         <div class="w-full px-4 lg:w-10/12 xl:w-8/12">
           <div class="w-full">
             <h1
-              class="mb-6 text-[26px] font-bold leading-normal text-dark dark:text-white sm:text-3xl sm:leading-snug md:text-4xl md:leading-snug"
+              class="mb-6 text-[26px] font-bold leading-normal text-dark sm:text-3xl sm:leading-snug md:text-4xl md:leading-snug"
             >
               {title}
             </h1>
             <div class="flex flex-wrap items-center pb-4">
               <div class="flex items-center mb-4">
                 <p
-                  class="flex items-center mr-5 text-sm font-medium text-body-color dark:text-dark-6 md:mr-8"
+                  class="flex items-center mr-5 text-sm font-medium text-body-color md:mr-8"
                 >
                   <span class="mr-3">
                     <svg


### PR DESCRIPTION
#22 
Article titles weren't appearing for me, turned out they were white text on white background, caused by a dark-mode setting which wasn't working for me.

https://tailwindcss.com/docs/dark-mode

Would like to review in future, but want to have working consistently for now.